### PR TITLE
Upgrade egeloen/http-adapter to 0.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,21 +12,21 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "egeloen/http-adapter": "~0.6.0@dev",
+        "egeloen/http-adapter": "~0.6.0",
         "symfony/framework-bundle": "~2.1"
     },
     "require-dev": {
-        "cakephp/cakephp": "~2.0",
+        "cakephp/cakephp": "^2.5.7",
         "ext-curl": "*",
-        "guzzle/guzzle": "~3.9,>=3.9.2",
-        "guzzlehttp/guzzle": "~4.1,>=4.1.4|~5.0",
+        "guzzle/guzzle": "^3.9.2",
+        "guzzlehttp/guzzle": ">=4.1.4,<6.0.0",
         "kriswallsmith/buzz": "~0.13",
         "nategood/httpful": "~0.2,>=0.2.17",
         "phpunit/phpunit": "~4.0",
         "psr/log": "~1.0",
         "react/http-client": "~0.4",
         "satooshi/php-coveralls": "~0.6",
-        "zendframework/zendframework1": "~1.12,>=1.12.9",
+        "zendframework/zendframework1": "^1.12.9",
         "zendframework/zend-http": "~2.0"
     },
     "autoload": {
@@ -37,7 +37,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.6-dev"
+            "dev-master": "0.7-dev"
         }
     }
 }


### PR DESCRIPTION
Hi Eric,

this is for projects relying on the 0.6.* edition of the Ivory Http Adapter - if you could provide a Github Release for that, this would be great!

I executed the Unit Tests, so I assume that everything is fine :)

Cheers
:octocat: Jérôme